### PR TITLE
add tests specification index file

### DIFF
--- a/tests/completions/spec_index.json
+++ b/tests/completions/spec_index.json
@@ -1,0 +1,2 @@
+["completions-code.json", "completions-spec.json"]
+

--- a/tests/events/spec_index.json
+++ b/tests/events/spec_index.json
@@ -1,0 +1,2 @@
+["events-file-support.json", "events.json", "events-large-file.json"]
+

--- a/tests/hover/spec_index.json
+++ b/tests/hover/spec_index.json
@@ -1,0 +1,2 @@
+["hover-blacklisted.json", "hover-whitelisted.json"]
+

--- a/tests/notifications/spec_index.json
+++ b/tests/notifications/spec_index.json
@@ -1,0 +1,1 @@
+["notification-blacklist.json", "notification-whitelist.json"]

--- a/tests/signatures/spec_index.json
+++ b/tests/signatures/spec_index.json
@@ -1,0 +1,2 @@
+["completions-signature.json"
+]


### PR DESCRIPTION
This PR adds an index file that could be consulted remotely by any plugin to know which specification files must be loaded in any given features directory. This is used by the Sublime Text 3 test runner as it directly loads the specifications from Github using an HTTP request to `raw.githubusercontent.com`.

In this way the plugin doesn't need to have a copy of the code or use submodules that needs some maintenance. I think loading the specs directly on each run is the most effective way to execute this automated tests and the less intrusive from the stack point of view.

Another advantage of this approach is that anyone can be working in adding a new test specification file and push the data into the repository to share even if the spec is a work in progress because the file is not gonna be loaded and used unless it is added to the specifications index.

@abe33 and @jansorg let me know what you think about this, I really will love to have this added to the repository even if no other plugin uses this approach.