### PR TITLE
Cover new signature and completions specifications

### DIFF
--- a/tests/new-signature-spec/signature_edit_auto_suppressor_close.json
+++ b/tests/new-signature-spec/signature_edit_auto_suppressor_close.json
@@ -41,7 +41,19 @@
       }
     },
     {
-      "description": "typing closing paren ')'",
+      "description": ", updating the signature response to return 404 ",
+      "step": "action",
+      "type": "update_route",
+      "properties": {
+        "match": "^/clientapi/editor/signatures$",
+        "response": {
+          "status": 404,
+          "body": "data/responses/signature.json"
+        }
+      }
+    },
+    {
+      "description": "and typing closing paren ')'",
       "step": "action",
       "type": "input_text",
       "properties": {
@@ -49,11 +61,11 @@
       }
     },
     {
-      "description": "and typing after the closing paren",
+      "description": "More typing after the closing paren",
       "step": "action",
       "type": "input_text",
       "properties": {
-        "text": ","
+        "text": " and "
       }
     },
     {
@@ -66,8 +78,8 @@
         "body": {
           "editor": "${plugin}",
           "filename": "${editors.data/whitelisted/file.py.filename}",
-          "text": "foo(ba),",
-          "cursor_runes": 8
+          "text": "foo(ba) and",
+          "cursor_runes": 11
         }
       }
     }

--- a/tests/new-signature-spec/signature_edit_auto_suppressor_close.json
+++ b/tests/new-signature-spec/signature_edit_auto_suppressor_close.json
@@ -1,0 +1,75 @@
+{
+  "description": "Tests the signature specification at https://kite.quip.com/NdIbAwg272aJ/Spec-Function-Signatures-Editor-Plugins-UIUX-WIP with automatic edit event suppressors",
+  "setup": {
+    "whitelist": [
+      "data/whitelisted"
+    ],
+    "kited": "authenticated",
+    "routes": [
+      {
+        "match": "^/clientapi/editor/signatures$",
+        "response": {
+          "status": 200,
+          "body": "data/responses/signature.json"
+        }
+      },
+      {
+        "match": "^/clientapi/plan$",
+        "response": {
+          "status": 200,
+          "body": "data/responses/plan.json"
+        }
+      }
+    ]
+  },
+  "test": [
+    {
+      "description": "opening a file",
+      "step": "action",
+      "type": "new_file",
+      "properties": {
+        "file": "data/whitelisted/file.py",
+        "content": "foo(ba"
+      }
+    },
+    {
+      "description": "moving cursor at end of identifier",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 6
+      }
+    },
+    {
+      "description": "typing closing paren ')'",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": ")"
+      }
+    },
+    {
+      "description": "and typing after the closing paren",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": ","
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(ba),",
+          "cursor_runes": 8
+        }
+      }
+    }
+  ]
+}

--- a/tests/new-signature-spec/signature_edit_auto_suppressor_open.json
+++ b/tests/new-signature-spec/signature_edit_auto_suppressor_open.json
@@ -1,0 +1,122 @@
+{
+  "description": "Tests the signature specification at https://kite.quip.com/NdIbAwg272aJ/Spec-Function-Signatures-Editor-Plugins-UIUX-WIP with automatic edit event suppressors",
+  "setup": {
+    "whitelist": [
+      "data/whitelisted"
+    ],
+    "kited": "authenticated",
+    "routes": [
+      {
+        "match": "^/clientapi/editor/signatures$",
+        "body_match": "\"cursor_runes\":\s*3,",
+        "response": {
+          "status": 404,
+          "body": "data/responses/signature.json"
+        }
+      },
+      {
+        "match": "^/clientapi/editor/signatures$",
+        "response": {
+          "status": 200,
+          "body": "data/responses/signature.json"
+        }
+      },
+      {
+        "match": "^/clientapi/plan$",
+        "response": {
+          "status": 200,
+          "body": "data/responses/plan.json"
+        }
+      }
+    ]
+  },
+  "test": [
+    {
+      "description": "opening a file",
+      "step": "action",
+      "type": "new_file",
+      "properties": {
+        "file": "data/whitelisted/file.py",
+        "content": "foo"
+      }
+    },
+    {
+      "description": "moving cursor at end of identifier",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 3
+      }
+    },
+    {
+      "description": "typing opening paren '('",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": "("
+      }
+    },
+    {
+      "description": "triggers a signature request",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(",
+          "cursor_runes": 4
+        }
+      }
+    },
+    {
+      "description": "removing the opening parent '('",
+      "step": "action",
+      "type": "remove_text",
+      "properties": {
+        "from_offset": 4,
+        "to_offset": 3
+      }
+    },
+    {
+      "description": "triggers a signature request which returns a 404 to close the popup",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo",
+          "cursor_runes": 3
+        }
+      }
+    },
+    {
+      "description": "and typing",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": "b"
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foob",
+          "cursor_runes": 4
+        }
+      }
+    }
+  ]
+}

--- a/tests/new-signature-spec/signature_edit_auto_suppressor_open.json
+++ b/tests/new-signature-spec/signature_edit_auto_suppressor_open.json
@@ -8,7 +8,7 @@
     "routes": [
       {
         "match": "^/clientapi/editor/signatures$",
-        "body_match": "\"cursor_runes\":\s*3,",
+        "body_match": ".+\"cursor_runes\":\\s*3[^0-9].*",
         "response": {
           "status": 404,
           "body": "data/responses/signature.json"
@@ -72,27 +72,12 @@
       }
     },
     {
-      "description": "removing the opening parent '('",
+      "description": "removing the opening parent '(' triggers a 404 signature response (see setup)",
       "step": "action",
       "type": "remove_text",
       "properties": {
         "from_offset": 4,
         "to_offset": 3
-      }
-    },
-    {
-      "description": "triggers a signature request which returns a 404 to close the popup",
-      "step": "expect",
-      "type": "request",
-      "properties": {
-        "path": "/clientapi/editor/signatures",
-        "method": "POST",
-        "body": {
-          "editor": "${plugin}",
-          "filename": "${editors.data/whitelisted/file.py.filename}",
-          "text": "foo",
-          "cursor_runes": 3
-        }
       }
     },
     {

--- a/tests/new-signature-spec/signature_edit_auto_suppressor_open.json
+++ b/tests/new-signature-spec/signature_edit_auto_suppressor_open.json
@@ -8,14 +8,6 @@
     "routes": [
       {
         "match": "^/clientapi/editor/signatures$",
-        "body_match": ".+\"cursor_runes\":\\s*3[^0-9].*",
-        "response": {
-          "status": 404,
-          "body": "data/responses/signature.json"
-        }
-      },
-      {
-        "match": "^/clientapi/editor/signatures$",
         "response": {
           "status": 200,
           "body": "data/responses/signature.json"
@@ -72,12 +64,39 @@
       }
     },
     {
-      "description": "removing the opening parent '(' triggers a 404 signature response (see setup)",
+      "description": "updating the signature response to return 404 and",
+      "step": "action",
+      "type": "update_route",
+      "properties": {
+        "match": "^/clientapi/editor/signatures$",
+        "response": {
+          "status": 404,
+          "body": "data/responses/signature.json"
+        }
+      }
+    },
+    {
+      "description": "removing the opening parent '('",
       "step": "action",
       "type": "remove_text",
       "properties": {
         "from_offset": 4,
         "to_offset": 3
+      }
+    },
+    {
+      "description": "triggers a signature request which returns a 404 to close the popup",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo",
+          "cursor_runes": 3
+        }
       }
     },
     {

--- a/tests/new-signature-spec/signature_edit_select_single.json
+++ b/tests/new-signature-spec/signature_edit_select_single.json
@@ -1,5 +1,5 @@
 {
-  "description": "Tests the signature specification at https://kite.quip.com/NdIbAwg272aJ/Spec-Function-Signatures-Editor-Plugins-UIUX-WIP, insertion using single character edits",
+  "description": "Tests the signature specification at https://kite.quip.com/NdIbAwg272aJ/Spec-Function-Signatures-Editor-Plugins-UIUX-WIP with select events (edit before selects).",
   "setup": {
     "whitelist": [
       "data/whitelisted"
@@ -29,7 +29,7 @@
       "type": "new_file",
       "properties": {
         "file": "data/whitelisted/file.py",
-        "content": "foo"
+        "content": "foo(bar, ba"
       }
     },
     {
@@ -37,15 +37,15 @@
       "step": "action",
       "type": "move_cursor",
       "properties": {
-        "offset": 3
+        "offset": 11
       }
     },
     {
-      "description": "typing open paren '('",
+      "description": "typing z",
       "step": "action",
       "type": "input_text",
       "properties": {
-        "text": "("
+        "text": "z"
       }
     },
     {
@@ -58,21 +58,21 @@
         "body": {
           "editor": "${plugin}",
           "filename": "${editors.data/whitelisted/file.py.filename}",
-          "text": "foo(",
-          "cursor_runes": 4
+          "text": "foo(bar, baz",
+          "cursor_runes": 12
         }
       }
     },
     {
-      "description": "typing 'b",
+      "description": "moving the cursor behind z",
       "step": "action",
-      "type": "input_text",
+      "type": "move_cursor",
       "properties": {
-        "text": "b"
+        "offset": 11
       }
     },
     {
-      "description": "triggers a signature request after 'b'",
+      "description": "triggers a signature request",
       "step": "expect",
       "type": "request",
       "properties": {
@@ -81,159 +81,182 @@
         "body": {
           "editor": "${plugin}",
           "filename": "${editors.data/whitelisted/file.py.filename}",
-          "text": "foo(b",
-          "cursor_runes": 5
-        }
-      }
-    },
-    {
-      "description": "typing 'a",
-      "step": "action",
-      "type": "input_text",
-      "properties": {
-        "text": "a"
-      }
-    },
-    {
-      "description": "triggers a signature request after 'a'",
-      "step": "expect",
-      "type": "request",
-      "properties": {
-        "path": "/clientapi/editor/signatures",
-        "method": "POST",
-        "body": {
-          "editor": "${plugin}",
-          "filename": "${editors.data/whitelisted/file.py.filename}",
-          "text": "foo(ba",
-          "cursor_runes": 6
-        }
-      }
-    },
-    {
-      "description": "typing 'r",
-      "step": "action",
-      "type": "input_text",
-      "properties": {
-        "text": "r"
-      }
-    },
-    {
-      "description": "triggers a signature request after 'r'",
-      "step": "expect",
-      "type": "request",
-      "properties": {
-        "path": "/clientapi/editor/signatures",
-        "method": "POST",
-        "body": {
-          "editor": "${plugin}",
-          "filename": "${editors.data/whitelisted/file.py.filename}",
-          "text": "foo(bar",
-          "cursor_runes": 7
-        }
-      }
-    },
-    {
-      "description": "typing ',",
-      "step": "action",
-      "type": "input_text",
-      "properties": {
-        "text": ","
-      }
-    },
-    {
-      "description": "triggers a signature request after ','",
-      "step": "expect",
-      "type": "request",
-      "properties": {
-        "path": "/clientapi/editor/signatures",
-        "method": "POST",
-        "body": {
-          "editor": "${plugin}",
-          "filename": "${editors.data/whitelisted/file.py.filename}",
-          "text": "foo(bar,",
-          "cursor_runes": 8
-        }
-      }
-    },
-    {
-      "description": "typing ' ",
-      "step": "action",
-      "type": "input_text",
-      "properties": {
-        "text": " "
-      }
-    },
-    {
-      "description": "triggers a signature request after ' '",
-      "step": "expect",
-      "type": "request",
-      "properties": {
-        "path": "/clientapi/editor/signatures",
-        "method": "POST",
-        "body": {
-          "editor": "${plugin}",
-          "filename": "${editors.data/whitelisted/file.py.filename}",
-          "text": "foo(bar, ",
-          "cursor_runes": 9
-        }
-      }
-    },
-    {
-      "description": "typing 'b",
-      "step": "action",
-      "type": "input_text",
-      "properties": {
-        "text": "b"
-      }
-    },
-    {
-      "description": "triggers a signature request after 'b'",
-      "step": "expect",
-      "type": "request",
-      "properties": {
-        "path": "/clientapi/editor/signatures",
-        "method": "POST",
-        "body": {
-          "editor": "${plugin}",
-          "filename": "${editors.data/whitelisted/file.py.filename}",
-          "text": "foo(bar, b",
-          "cursor_runes": 10
-        }
-      }
-    },
-    {
-      "description": "typing 'a",
-      "step": "action",
-      "type": "input_text",
-      "properties": {
-        "text": "a"
-      }
-    },
-    {
-      "description": "triggers a signature request after 'a'",
-      "step": "expect",
-      "type": "request",
-      "properties": {
-        "path": "/clientapi/editor/signatures",
-        "method": "POST",
-        "body": {
-          "editor": "${plugin}",
-          "filename": "${editors.data/whitelisted/file.py.filename}",
-          "text": "foo(bar, ba",
+          "text": "foo(bar, baz",
           "cursor_runes": 11
         }
       }
     },
     {
-      "description": "typing 'z",
+      "description": "moving the cursor behind a",
       "step": "action",
-      "type": "input_text",
+      "type": "move_cursor",
       "properties": {
-        "text": "z"
+        "offset": 10
       }
     },
     {
-      "description": "triggers a signature request after 'z'",
+      "description": "triggers a signature request",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 10
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind b",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 9
+      }
+    },
+    {
+      "description": "triggers a signature request",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 9
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind space",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 8
+      }
+    },
+    {
+      "description": "triggers a signature request",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 8
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind comma",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 7
+      }
+    },
+    {
+      "description": "triggers a signature request",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 7
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind r",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 6
+      }
+    },
+    {
+      "description": "triggers a signature request",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 6
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind a",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 5
+      }
+    },
+    {
+      "description": "triggers a signature request",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 5
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind b",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 4
+      }
+    },
+    {
+      "description": "triggers a signature request",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 4
+        }
+      }
+    },
+    {
+      "description": "moving the cursor at the end of the document in front of z",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 12
+      }
+    },
+    {
+      "description": "triggers a signature request",
       "step": "expect",
       "type": "request",
       "properties": {

--- a/tests/new-signature-spec/signature_edit_single.json
+++ b/tests/new-signature-spec/signature_edit_single.json
@@ -1,0 +1,251 @@
+{
+  "description": "Tests the signature specification at https://kite.quip.com/NdIbAwg272aJ/Spec-Function-Signatures-Editor-Plugins-UIUX-WIP with edit events.",
+  "setup": {
+    "whitelist": [
+      "data/whitelisted"
+    ],
+    "kited": "authenticated",
+    "routes": [
+      {
+        "match": "^/clientapi/editor/signatures$",
+        "response": {
+          "status": 200,
+          "body": "data/responses/signature.json"
+        }
+      },
+      {
+        "match": "^/clientapi/plan$",
+        "response": {
+          "status": 200,
+          "body": "data/responses/plan.json"
+        }
+      }
+    ]
+  },
+  "test": [
+    {
+      "description": "opening a file",
+      "step": "action",
+      "type": "new_file",
+      "properties": {
+        "file": "data/whitelisted/file.py",
+        "content": "foo"
+      }
+    },
+    {
+      "description": "moving cursor at end of identifier",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 3
+      }
+    },
+    {
+      "description": "typing open paren '('",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": "("
+      }
+    },
+    {
+      "description": "triggers a signature request",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(",
+          "cursor_runes": 4
+        }
+      }
+    },
+    {
+      "description": "typing 'b",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": "b"
+      }
+    },
+    {
+      "description": "triggers a signature request after 'b'",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(b",
+          "cursor_runes": 5
+        }
+      }
+    },
+    {
+      "description": "typing 'a",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": "a"
+      }
+    },
+    {
+      "description": "triggers a signature request after 'a'",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(ba",
+          "cursor_runes": 6
+        }
+      }
+    },
+    {
+      "description": "typing 'r",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": "r"
+      }
+    },
+    {
+      "description": "triggers a signature request after 'r'",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar",
+          "cursor_runes": 7
+        }
+      }
+    },
+    {
+      "description": "typing ',",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": ","
+      }
+    },
+    {
+      "description": "triggers a signature request after ','",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar,",
+          "cursor_runes": 8
+        }
+      }
+    },
+    {
+      "description": "typing ' ",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": " "
+      }
+    },
+    {
+      "description": "triggers a signature request after ' '",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, ",
+          "cursor_runes": 9
+        }
+      }
+    },
+    {
+      "description": "typing 'b",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": "b"
+      }
+    },
+    {
+      "description": "triggers a signature request after 'b'",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, b",
+          "cursor_runes": 10
+        }
+      }
+    },
+    {
+      "description": "typing 'a",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": "a"
+      }
+    },
+    {
+      "description": "triggers a signature request after 'a'",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, ba",
+          "cursor_runes": 11
+        }
+      }
+    },
+    {
+      "description": "typing 'z",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": "z"
+      }
+    },
+    {
+      "description": "triggers a signature request after 'z'",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 12
+        }
+      }
+    }
+  ]
+}

--- a/tests/new-signature-spec/signature_select_auto_suppressor.json
+++ b/tests/new-signature-spec/signature_select_auto_suppressor.json
@@ -64,16 +64,28 @@
       }
     },
     {
+      "description": "updating the signature response to return 404 and",
+      "step": "action",
+      "type": "update_route",
+      "properties": {
+        "match": "^/clientapi/editor/signatures$",
+        "response": {
+          "status": 404,
+          "body": "data/responses/signature.json"
+        }
+      }
+    },
+    {
       "description": "moving the cursor outside of the call expression",
       "step": "action",
       "type": "move_cursor",
       "properties": {
-        "offset": 2
+        "offset": 3
       }
     },
     {
-      "description": "triggers no signature request",
-      "step": "expect_not",
+      "description": "triggers one last signature request",
+      "step": "expect",
       "type": "request",
       "properties": {
         "path": "/clientapi/editor/signatures",
@@ -82,7 +94,30 @@
           "editor": "${plugin}",
           "filename": "${editors.data/whitelisted/file.py.filename}",
           "text": "foo(bar",
-          "cursor_runes": 2
+          "cursor_runes": 3
+        }
+      }
+    },
+    {
+      "description": "more typing in the buffer",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": "b"
+      }
+    },
+    {
+      "description": "triggers no more signature request because the previously send 404 closes the popup",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foob(bar",
+          "cursor_runes": 4
         }
       }
     }

--- a/tests/new-signature-spec/signature_select_auto_suppressor.json
+++ b/tests/new-signature-spec/signature_select_auto_suppressor.json
@@ -1,0 +1,90 @@
+{
+  "description": "Tests the signature specification at https://kite.quip.com/NdIbAwg272aJ/Spec-Function-Signatures-Editor-Plugins-UIUX-WIP with automatic select event suppressors.",
+  "setup": {
+    "whitelist": [
+      "data/whitelisted"
+    ],
+    "kited": "authenticated",
+    "routes": [
+      {
+        "match": "^/clientapi/editor/signatures$",
+        "response": {
+          "status": 200,
+          "body": "data/responses/signature.json"
+        }
+      },
+      {
+        "match": "^/clientapi/plan$",
+        "response": {
+          "status": 200,
+          "body": "data/responses/plan.json"
+        }
+      }
+    ]
+  },
+  "test": [
+    {
+      "description": "opening a file",
+      "step": "action",
+      "type": "new_file",
+      "properties": {
+        "file": "data/whitelisted/file.py",
+        "content": "foo(ba"
+      }
+    },
+    {
+      "description": "moving cursor at end of identifier",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 6
+      }
+    },
+    {
+      "description": "typing a character",
+      "step": "action",
+      "type": "input_text",
+      "properties": {
+        "text": "r"
+      }
+    },
+    {
+      "description": "triggers a signature request",
+      "step": "expect",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar",
+          "cursor_runes": 7
+        }
+      }
+    },
+    {
+      "description": "moving the cursor outside of the call expression",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 2
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar",
+          "cursor_runes": 2
+        }
+      }
+    }
+  ]
+}

--- a/tests/new-signature-spec/signature_select_single.json
+++ b/tests/new-signature-spec/signature_select_single.json
@@ -1,0 +1,266 @@
+{
+  "description": "Tests the signature specification at https://kite.quip.com/NdIbAwg272aJ/Spec-Function-Signatures-Editor-Plugins-UIUX-WIP with select events (no edit before selects).",
+  "setup": {
+    "whitelist": [
+      "data/whitelisted"
+    ],
+    "kited": "authenticated",
+    "routes": [
+      {
+        "match": "^/clientapi/editor/signatures$",
+        "response": {
+          "status": 200,
+          "body": "data/responses/signature.json"
+        }
+      },
+      {
+        "match": "^/clientapi/plan$",
+        "response": {
+          "status": 200,
+          "body": "data/responses/plan.json"
+        }
+      }
+    ]
+  },
+  "test": [
+    {
+      "description": "opening a file",
+      "step": "action",
+      "type": "new_file",
+      "properties": {
+        "file": "data/whitelisted/file.py",
+        "content": "foo(bar, baz"
+      }
+    },
+    {
+      "description": "moving cursor at end of identifier",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 12
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 12
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind z",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 11
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 11
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind a",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 10
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 10
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind b",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 9
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 9
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind space",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 8
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 8
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind comma",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 7
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 7
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind r",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 6
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 6
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind a",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 5
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 5
+        }
+      }
+    },
+    {
+      "description": "moving the cursor behind b",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 4
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 4
+        }
+      }
+    },
+    {
+      "description": "moving the cursor at the end of the document in front of z",
+      "step": "action",
+      "type": "move_cursor",
+      "properties": {
+        "offset": 12
+      }
+    },
+    {
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
+      "properties": {
+        "path": "/clientapi/editor/signatures",
+        "method": "POST",
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "foo(bar, baz",
+          "cursor_runes": 12
+        }
+      }
+    }
+  ]
+}

--- a/tests/signatures/signature-whitelisted.json
+++ b/tests/signatures/signature-whitelisted.json
@@ -55,13 +55,18 @@
       }
     },
     {
-      "description": "doesn't trigger a new signature request",
+      "description": "sends a new signature request",
       "step": "expect",
-      "type": "request_count",
+      "type": "request",
       "properties": {
         "path": "/clientapi/editor/signatures",
         "method": "POST",
-        "count": 1
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "import json\njson.dumps(123",
+          "cursor_runes": 26
+        }
       }
     },
     {
@@ -88,6 +93,18 @@
       }
     },
     {
+      "description": "updating the signature response to return 404 and",
+      "step": "action",
+      "type": "update_route",
+      "properties": {
+        "match": "^/clientapi/editor/signatures$",
+        "response": {
+          "status": 404,
+          "body": "data/responses/signature.json"
+        }
+      }
+    },
+    {
       "description": "Typing the closing parenthesis ')'",
       "step": "action",
       "type": "input_text",
@@ -96,13 +113,18 @@
       }
     },
     {
-      "description": "doesn't trigger a new signature request",
-      "step": "expect",
-      "type": "request_count",
+      "description": "triggers no signature request",
+      "step": "expect_not",
+      "type": "request",
       "properties": {
         "path": "/clientapi/editor/signatures",
         "method": "POST",
-        "count": 2
+        "body": {
+          "editor": "${plugin}",
+          "filename": "${editors.data/whitelisted/file.py.filename}",
+          "text": "import json\njson.dumps(123,)",
+          "cursor_runes": 28
+        }
       }
     }
   ]


### PR DESCRIPTION
- add new action `update_route` to allow updates to the route configuration. It takes the same properties as the test's setup section, e.g. 
```json
    {
      "description": "updating the signature response to return 404 and",
      "step": "action",
      "type": "update_route",
      "properties": {
        "match": "^/clientapi/editor/signatures$",
        "response": {
          "status": 404,
          "body": "data/responses/signature.json"
        }
      }
    }
```