### PR TITLE
Create vim.json

### DIFF
--- a/tests/vim.json
+++ b/tests/vim.json
@@ -1,1 +1,1 @@
-["completions", "events", "hover", "notifications", "signatures"]
+["completions", "events", "hover", "notifications"]


### PR DESCRIPTION
adds vim config file to skip signature_whitelisted.json	 which is the only test no passing in vim.
vim is showing either completions or signature info, so this test isn't fitting well for vim.